### PR TITLE
Correção da exibição imagens do documento DesignSprint e Modelagem BPMN

### DIFF
--- a/docs/Base/1.1.DesignSprint.md
+++ b/docs/Base/1.1.DesignSprint.md
@@ -7,76 +7,88 @@ Segundo Serrano (2024), na etapa Unpack objetivo é gerar vários insights, prod
 Para isso, foi escolhida a técnica elicitação de requisitos Análise de Concorrentes. Segundo Marsicano (2024), esse método permite extrair informações valiosas sobre as necessidades dos clientes ao examinar soluções existentes. Analisamos os sites **OLX**, **Enjoei**, **TROC**, **Baú da Bia**, **Repassa** e **Garimpário**, identificando tanto características comuns quanto exclusivas. As principais funcionalidades identificadas foram:
 
 #### 1. Filtros de Busca e Organização
-   - Todos os sites oferecem filtros como categoria, preço (do menor para o maior e vice-versa) e opções específicas (tamanho, condição e popularidade) para facilitar a busca e a navegação.
+
+- Todos os sites oferecem filtros como categoria, preço (do menor para o maior e vice-versa) e opções específicas (tamanho, condição e popularidade) para facilitar a busca e a navegação.
 
 #### 2. Opções de Contato
-   - Há a possibilidade de contato com o vendedor por meio de redes sociais, e-mail ou WhatsApp.
+
+- Há a possibilidade de contato com o vendedor por meio de redes sociais, e-mail ou WhatsApp.
 
 #### 3. Login Unificado
-   - **OLX**, **Enjoei**, **TROC** e **Repassa** permitem que os usuários atuem tanto como compradores quanto como vendedores com uma única conta, evitando a necessidade de criar perfis distintos.
+
+- **OLX**, **Enjoei**, **TROC** e **Repassa** permitem que os usuários atuem tanto como compradores quanto como vendedores com uma única conta, evitando a necessidade de criar perfis distintos.
 
 #### 4. Interação com Produtos
-   - A maioria dos sites oferece meios de interação com os produtos, como comentários (**Enjoei**, **Baú da Bia**), chat para negociação (**OLX**) e listas de desejos (**Garimpário**).
+
+- A maioria dos sites oferece meios de interação com os produtos, como comentários (**Enjoei**, **Baú da Bia**), chat para negociação (**OLX**) e listas de desejos (**Garimpário**).
 
 #### 5. Promoções e Cupons de Desconto
-   - Artigos em promoção recebem destaque na página inicial. Além disso, é possível usar cupons de desconto nas compras.
+
+- Artigos em promoção recebem destaque na página inicial. Além disso, é possível usar cupons de desconto nas compras.
 
 #### 6. Sistema de Reembolso ou Devolução
-   - Alguns sites, como **Enjoei** e **Baú da Bia**, contam com políticas de reembolso e devolução aos consumidores.
+
+- Alguns sites, como **Enjoei** e **Baú da Bia**, contam com políticas de reembolso e devolução aos consumidores.
 
 #### 7. Entrega e Parcerias para Frete
-   - Muitos dos sites contam com serviços de entrega ou parcerias para envio, como **Enjoei** (Correios) e os sistemas de entrega próprios da **OLX** e **Repassa**.
+
+- Muitos dos sites contam com serviços de entrega ou parcerias para envio, como **Enjoei** (Correios) e os sistemas de entrega próprios da **OLX** e **Repassa**.
 
 #### 8. Informações sobre o Vendedor e o Produto
-   - Ao clicar em um produto, detalhes como descrição, medidas e peso são exibidos. No caso do **Enjoei**, é possível visualizar informações sobre o vendedor, como produtos à venda, vendidos, tempo de cadastro e avaliações.
+
+- Ao clicar em um produto, detalhes como descrição, medidas e peso são exibidos. No caso do **Enjoei**, é possível visualizar informações sobre o vendedor, como produtos à venda, vendidos, tempo de cadastro e avaliações.
 
 #### 9. Formas de Pagamento e Cálculo de Frete
-   - Os sites analisados oferecem múltiplas formas de pagamento (cartão de crédito/débito e PIX) e a possibilidade de cálculo do frete ao inserir o CEP.
+
+- Os sites analisados oferecem múltiplas formas de pagamento (cartão de crédito/débito e PIX) e a possibilidade de cálculo do frete ao inserir o CEP.
 
 Essa pesquisa permitiu consolidar um entendimento amplo das funcionalidades essenciais de um brechó. Com base nela, foi elaborado um [Mapa Mental](/Base/1.2.ArtefatoGeneralista.md).
 
 ## Sketch
 
-Ainda segundo Serrano (2024), na fase *sketch* o objetivo é gerar desenhos de várias ideias, usando como base o que foi acordado na fase anterior, sob a perspectiva de cada membro da equipe.
+Ainda segundo Serrano (2024), na fase _sketch_ o objetivo é gerar desenhos de várias ideias, usando como base o que foi acordado na fase anterior, sob a perspectiva de cada membro da equipe.
 
-Pode-se dizer que aqui cada membro desenha como ele imagina que aquela ideia deva ocorrer, considerando o que foi debatido na fase *unpack*.
+Pode-se dizer que aqui cada membro desenha como ele imagina que aquela ideia deva ocorrer, considerando o que foi debatido na fase _unpack_.
 
 ### Rich Picture
 
-#### Introdução 
+#### Introdução
 
-*Rich Picture* é uma representação visual de uma ideia, feito a mão livre ou com ferramentas, para representar atividades, ideias, entre outros. Nos *Rich Pictures* elaborados, os usuários incluem compradores em busca de produtos sustentáveis e vendedores que desejam desapegar de roupas. A plataforma deve ser intuitiva, facilitando o cadastro de produtos e a navegação. Os processos envolvem desde a listagem de itens até o sistema de pagamento. As interações entre compradores e vendedores, como perguntas e avaliações, são essenciais para criar confiança e engajamento.
+_Rich Picture_ é uma representação visual de uma ideia, feito a mão livre ou com ferramentas, para representar atividades, ideias, entre outros. Nos _Rich Pictures_ elaborados, os usuários incluem compradores em busca de produtos sustentáveis e vendedores que desejam desapegar de roupas. A plataforma deve ser intuitiva, facilitando o cadastro de produtos e a navegação. Os processos envolvem desde a listagem de itens até o sistema de pagamento. As interações entre compradores e vendedores, como perguntas e avaliações, são essenciais para criar confiança e engajamento.
 
-Os *Rich Pictures* (RPs) para *Sketch* foram feitos para ilustrar processos do brechó sob a perspectiva de diferentes membros com base nos resultados da fase **Design Sprint - Unpack**.
+Os _Rich Pictures_ (RPs) para _Sketch_ foram feitos para ilustrar processos do brechó sob a perspectiva de diferentes membros com base nos resultados da fase **Design Sprint - Unpack**.
 
 #### RP1
 
 <center>
-<img src="../Imagens/RP1.png" alt="rich picture" width="800"/>
+<img src="https://github.com/UnBArqDsw2024-2/2024.2_G2_Brecho_Entrega_01/blob/main/docs/Imagens/RP1.png?raw=true" alt="rich picture" width="800"/>
 
 Figura 1 - Rich Picture 1.
 
 Fonte: Ana L. H. Ferreira
+
 </center>
 
 #### RP2
 
 <center>
-<img src="../Imagens/RP2.jpeg" alt="rich picture" width="800"/>
+<img src="https://github.com/UnBArqDsw2024-2/2024.2_G2_Brecho_Entrega_01/blob/main/docs/Imagens/RP2.jpeg?raw=true" alt="rich picture" width="800"/>
 
 Figura 2 - Rich Picture 2.
 
 Fonte: Rodrigo Gontijo
+
 </center>
 
 #### RP3
 
 <center>
-<img src="../Imagens/RP3.png" alt="rich picture" width="800"/>
+<img src="https://github.com/UnBArqDsw2024-2/2024.2_G2_Brecho_Entrega_01/blob/main/docs/Imagens/RP3.png?raw=true" alt="rich picture" width="800"/>
 
 Figura 3 - Rich Picture 3.
 
 Fonte: Luiz G. P. Pettengill
+
 </center>
 
 ## Decision
@@ -89,26 +101,30 @@ Além disso, a Rich Picture escolhida mostra claramente de onde os dados são ob
 
 ## Protótipo
 
-Aqui foi feita algumas telas de protótipo para conseguirmos dimensionar como ficarâo alguns requisitos e a estilização da aplicação.
+Aqui foi feita algumas telas de protótipo para conseguirmos dimensionar como ficarão alguns requisitos e a estilização da aplicação.
 
 ### Tela de Login
+
 <center>
-<img src="../Imagens/login.jpeg" alt="login" width="800"/>
+<img src="https://github.com/UnBArqDsw2024-2/2024.2_G2_Brecho_Entrega_01/blob/main/docs/Imagens/login.jpeg?raw=true" alt="login" width="800"/>
 </center>
 
 ### Tela de Cadastro
+
 <center>
-<img src="../Imagens/cadastro.jpeg" alt="cadastro" width="800"/>
+<img src="https://github.com/UnBArqDsw2024-2/2024.2_G2_Brecho_Entrega_01/blob/main/docs/Imagens/cadastro.jpeg?raw=true" alt="cadastro" width="800"/>
 </center>
 
 ### Home da Aplicação
+
 <center>
-<img src="../Imagens/home.jpeg" alt="home" width="800"/>
+<img src="https://github.com/UnBArqDsw2024-2/2024.2_G2_Brecho_Entrega_01/blob/main/docs/Imagens/home.jpeg?raw=true" alt="home" width="800"/>
 </center>
 
 ### Tela de Produto
+
 <center>
-<img src="../Imagens/produto.jpeg" alt="prduto" width="800"/>
+<img src="https://github.com/UnBArqDsw2024-2/2024.2_G2_Brecho_Entrega_01/blob/main/docs/Imagens/produto.jpeg?raw=true" alt="prduto" width="800"/>
 </center>
 
 ## Referência Bibliográfica
@@ -120,10 +136,11 @@ Aqui foi feita algumas telas de protótipo para conseguirmos dimensionar como fi
 
 ## Histórico de Versões
 
-| Versão | Data       | Descrição                  | Autor(es)                                                                                                                             | Revisor(es)                                              |
-| ------ | ---------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
-| `1.0`  | 31/10/2024 | Adição da etapa Unpack     | [LucasSpinosa](https://github.com/LucasSpinosa), [Marco Tulio](https://github.com/MarcoTulioSoares), [Douglas Marinho](https://github.com/M4RINH0) | [Luiz Pettengill](https://github.com/LuizPettengill)     |
-| `1.1`  | 01/11/2024 | Adição de link para Mapa Mental | [LucasSpinosa](https://github.com/LucasSpinosa)                                                                                       |                                                          |
-| `1.2`  | 03/11/2024 | Adição da etapa Sketch + Rich Pictures | [Ana Hoffmann](https://github.com/AnHoff) e [Luiz Pettengill](https://github.com/LuizPettengill) | [Lucas Spinosa](https://github.com/LucasSpinosa) |
-| `1.3`  | 03/11/2024 | Adição da etapa de Decision | [Eric Camargo](https://github.com/ericcs10), [Henrique Torres](https://github.com/henriqtorresl)                                      | [Lucas Spinosa](https://github.com/LucasSpinosa)        |
-| `1.4`  | 03/11/2024 | Adição da etapa de Protótipo | [Guilherme Evangelista](https://github.com/guinuto)| [Lucas Spinosa](https://github.com/LucasSpinosa)        |
+| Versão | Data       | Descrição                                 | Autor(es)                                                                                                                                          | Revisor(es)                                          |
+| ------ | ---------- | ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| `1.0`  | 31/10/2024 | Adição da etapa Unpack                    | [LucasSpinosa](https://github.com/LucasSpinosa), [Marco Tulio](https://github.com/MarcoTulioSoares), [Douglas Marinho](https://github.com/M4RINH0) | [Luiz Pettengill](https://github.com/LuizPettengill) |
+| `1.1`  | 01/11/2024 | Adição de link para Mapa Mental           | [LucasSpinosa](https://github.com/LucasSpinosa)                                                                                                    |                                                      |
+| `1.2`  | 03/11/2024 | Adição da etapa Sketch + Rich Pictures    | [Ana Hoffmann](https://github.com/AnHoff) e [Luiz Pettengill](https://github.com/LuizPettengill)                                                   | [Lucas Spinosa](https://github.com/LucasSpinosa)     |
+| `1.3`  | 03/11/2024 | Adição da etapa de Decision               | [Eric Camargo](https://github.com/ericcs10), [Henrique Torres](https://github.com/henriqtorresl)                                                   | [Lucas Spinosa](https://github.com/LucasSpinosa)     |
+| `1.4`  | 03/11/2024 | Adição da etapa de Protótipo              | [Guilherme Evangelista](https://github.com/guinuto)                                                                                                | [Lucas Spinosa](https://github.com/LucasSpinosa)     |
+| `1.5`  | 04/11/2024 | Correção da exibição imagens do documento | [Marcelo Magalhães](https://github.com/marrcelo)                                                                                                   |                                                      |

--- a/docs/Base/1.3.ModelagemBPMN.md
+++ b/docs/Base/1.3.ModelagemBPMN.md
@@ -3,22 +3,22 @@
 ## BPMN 1 - Compra de um Item
 
 <center>
-<img src="../Imagens/bpnm_1.png"/>
+<img src="https://github.com/UnBArqDsw2024-2/2024.2_G2_Brecho_Entrega_01/blob/main/docs/Imagens/bpnm_1.png?raw=true"/>
 
 Figura 2 - Rich Picture 2.
 
 Fonte: [Ana Hoffmann](https://github.com/AnHoff), [LucasSpinosa](https://github.com/LucasSpinosa) e [Luiz Pettengill](https://github.com/LuizPettengill)
+
 </center>
 
 O diagrama BPMN apresentado descreve o fluxo de compra de um item no brechó. O fluxo começa com o usuário acessando o site e explorando o catálogo em busca de um artigo. Ao achar algo de interesse, deve então realizar o login ou se cadastrar para poder utilizar o carrinho de compras e adicionar o produto a ele.
 
 Feito isso, avança para a página de pagamento, confirma se os dados do pedido estão corretos (como o endereço da entrega, por exemplo), seleciona o frete desejado para a entrega e realiza o pagamento. Nesse momento, o sistema emite a nota fiscal. Ao usuário receber a nota fiscal, o processo de compra é encerrado.
 
-
 ## BPMN 2 - Deixar Avaliação de Item
 
 <div style="width: 100%; display: flex; justify-content: center; align-items: center;">
-    <img alt="BPMN 2 - Elaborado por Henrique Torres e Eric Camargo" src="../Imagens/bpnm_2.jpeg">
+    <img alt="BPMN 2 - Elaborado por Henrique Torres e Eric Camargo" src="https://github.com/UnBArqDsw2024-2/2024.2_G2_Brecho_Entrega_01/blob/main/docs/Imagens/bpnm_2.jpeg?raw=true">
 </div>
 
 <div style="width: 100%; display: flex; justify-content: center; align-items: center;">Fonte:<a href="https://github.com/henriqtorresl" style="margin-left: 2px; margin-right: 2px" target="_blank">Henrique Torres</a> e <a href="https://github.com/Ericcs10" style="margin-left: 2px;" target="_blank">Eric Camargo</a> </div>
@@ -34,11 +34,12 @@ Este diagrama foi projetado para manter uma estrutura compacta, evitando uma exp
 ## BPMN 3 - Colocar Item à Venda
 
 <center>
-<img src="../Imagens/bpnm_3.png"/>
+<img src="https://github.com/UnBArqDsw2024-2/2024.2_G2_Brecho_Entrega_01/blob/main/docs/Imagens/bpnm_3.png?raw=true"/>
 
 Figura 3 - BPMN 3.
 
 Fonte: [Marcelo Ferreira](https://github.com/marrcelo), [Marco Tulio](https://github.com/MarcoTulioSoares) e [Rodrigo Gontijo](https://github.com/rodrigogontijoo)
+
 </center>
 
 O diagrama BPMN apresentado descreve o fluxo de colocar um item à venda no brechó. O fluxo começa verificando se o vendedor possui cadastro ou não, pois para anunciar um item, é preciso estar cadastrado. Em seguida, o vendedor fornece todos os dados necessários para vender um produto. No fim, se o vendedor deseja revisar os dados que ele inseriu, ele volta novamente para a parte de fornecer os dados. Se isso não é do interesse do vendedor, o anúncio é criado e o fluxo é finalizado.
@@ -46,7 +47,7 @@ O diagrama BPMN apresentado descreve o fluxo de colocar um item à venda no brec
 ## BPMN 4 - Rastrear Pedido
 
 <div style="width: 100%; display: flex; justify-content: center; align-items: center;">
-    <img alt="BPMN 4 - Elaborado por Eric Camargo e Henrique Torres" src="../Imagens/bpnm_4.jpeg">
+    <img alt="BPMN 4 - Elaborado por Eric Camargo e Henrique Torres" src="https://github.com/UnBArqDsw2024-2/2024.2_G2_Brecho_Entrega_01/blob/main/docs/Imagens/bpnm_4.jpeg?raw=true">
 </div>
 
 <div style="width: 100%; display: flex; justify-content: center; align-items: center;">Fonte:<a href="https://github.com/henriqtorresl" style="margin-left: 2px; margin-right: 2px" target="_blank">Henrique Torres</a> e <a href="https://github.com/Ericcs10" style="margin-left: 2px;" target="_blank">Eric Camargo</a> </div>
@@ -61,9 +62,9 @@ O usuário pode optar por continuar monitorando o pedido, mantendo o acompanhame
 
 ## Histórico de Versões
 
-| Versão | Data       | Descrição             | Autor(es)                                                                                         | Revisor(es)                               |
-| ------ | ---------- | --------------------- | ------------------------------------------------------------------------------------------------- | ----------------------------------------- |
-| `1.0`  | 01/10/2024 | Adição dos BPMN 2 e 4 | [Henrique Torres](https://github.com/henriqtorresl) e [Eric Camargo](https://github.com/Ericcs10) | [Ana Hoffmann](https://github.com/AnHoff) |
-| `1.1`  | 03/10/2024 | Adição do BPMN 1 | [Lucas Spinosa](https://github.com/LucasSpinosa), [Ana Hoffmann](https://github.com/AnHoff) e [Luiz Pettengill](https://github.com/LuizPettengill) | [Ana Hoffmann](https://github.com/AnHoff) |
-| `1.2`  | 03/10/2024 | Adição do BPMN 3 |[Marcelo Ferreira](https://github.com/marrcelo), [Marco Tulio](https://github.com/MarcoTulioSoares) e [Rodrigo Gontijo](https://github.com/rodrigogontijoo) | [Lucas Spinosa](https://github.com/LucasSpinosa) |
-
+| Versão | Data       | Descrição                                 | Autor(es)                                                                                                                                                   | Revisor(es)                                      |
+| ------ | ---------- | ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| `1.0`  | 01/10/2024 | Adição dos BPMN 2 e 4                     | [Henrique Torres](https://github.com/henriqtorresl) e [Eric Camargo](https://github.com/Ericcs10)                                                           | [Ana Hoffmann](https://github.com/AnHoff)        |
+| `1.1`  | 03/10/2024 | Adição do BPMN 1                          | [Lucas Spinosa](https://github.com/LucasSpinosa), [Ana Hoffmann](https://github.com/AnHoff) e [Luiz Pettengill](https://github.com/LuizPettengill)          | [Ana Hoffmann](https://github.com/AnHoff)        |
+| `1.2`  | 03/10/2024 | Adição do BPMN 3                          | [Marcelo Ferreira](https://github.com/marrcelo), [Marco Tulio](https://github.com/MarcoTulioSoares) e [Rodrigo Gontijo](https://github.com/rodrigogontijoo) | [Lucas Spinosa](https://github.com/LucasSpinosa) |
+| `1.3`  | 04/11/2024 | Correção da exibição imagens do documento | [Marcelo Magalhães](https://github.com/marrcelo)                                                                                                            |                                                  |


### PR DESCRIPTION
Correção da exibição imagens do documento DesignSprint e Modelagem BPMN.

Imagens não estavam sendo exibidas de forma correta no [site](https://unbarqdsw2024-2.github.io/2024.2_G2_Brecho_Entrega_01/#/Base/1.1.DesignSprint):

![image](https://github.com/user-attachments/assets/a2a8dc1c-7a07-4aa9-9623-6d6c656ba8de)



